### PR TITLE
Drop code.google.com/p/go.crypto/curve25519 and use golang.org/x/crypto/curve25519

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - 1.2
   - tip
 
-install: go get code.google.com/p/go.crypto/curve25519
+install: go get golang.org/x/crypto/curve25519
 
 script:
 - go get github.com/tang0th/go-ecdh 

--- a/curve25519.go
+++ b/curve25519.go
@@ -4,7 +4,7 @@ import (
 	"crypto"
 	"io"
 
-	"code.google.com/p/go.crypto/curve25519"
+	"golang.org/x/crypto/curve25519"
 )
 
 type curve25519ECDH struct {


### PR DESCRIPTION
Hi,

The old `code.google.com/...` triggers warnings (*) and might even break some builds.

(*) `warning: code.google.com is shutting down; import path code.google.com/p/go.crypto/curve25519 will stop working`
